### PR TITLE
Add proper colors for sticky header and minimap

### DIFF
--- a/themes/Daobeam-color-theme.json
+++ b/themes/Daobeam-color-theme.json
@@ -17,6 +17,8 @@
     "editor.inactiveSelectionBackground": "#E5EBF1",
     "editorIndentGuide.background": "#D3D3D3",
     "editor.selectionHighlightBackground": "#ADD6FF4D",
+    "editorStickyScroll.border": "#666666",
+    "editorStickyScroll.shadow": "#D1CAAB",
     "editorSuggestWidget.background": "#F3F3F3",
     "sideBarTitle.foreground": "#000000",
     "sideBarSectionHeader.foreground": "#000000",

--- a/themes/Daobeam-color-theme.json
+++ b/themes/Daobeam-color-theme.json
@@ -50,7 +50,8 @@
     "terminal.ansiBrightYellow": "#B95C00",
     "terminalCursor.foreground": "#ADADAD",
     "terminal.ansiGreen": "#005800",
-    "terminal.ansiBrightGreen": "#009100"
+    "terminal.ansiBrightGreen": "#009100",
+    "minimap.background": "#D1CAAB"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
Thanks for making this theme, it is very easy on the eyes!

This PR gives the sticky headers a proper border color, instead of the light grey that was barely visible. Also, I wanted to make the minimap visually distinct.

See screenshot for before and after. 

<img width="1198" height="453" alt="before-after" src="https://github.com/user-attachments/assets/05ca0607-0f8d-4dd0-92d3-0d8e82c88134" />
